### PR TITLE
MarkAsHelpful: Replace deprecated editToken with csrfToken

### DIFF
--- a/modules/ext.markAsHelpful/ext.markAsHelpful.js
+++ b/modules/ext.markAsHelpful/ext.markAsHelpful.js
@@ -104,7 +104,7 @@
 				page: mw.config.get( 'wgPageName' ),
 				useragent: clientData.name + '/' + clientData.versionNumber,
 				system: clientData.platform,
-				token: mw.user.tokens.get( 'editToken' )
+				token: mw.user.tokens.get( 'csrfToken' )
 			}, props );
 
 			$.ajax( {


### PR DESCRIPTION
The editToken key of mw.users.tokens is deprecated since MediaWiki 1.27.

Bug: T233552